### PR TITLE
Do not break if the lead image adapter cannot be initialized

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Changelog
 ## 3.7.5 (unreleased)
 
 
-- Nothing changed yet.
+- Do not break if the lead image adapter cannot be initialized (fixes [#25](https://github.com/collective/collective.behavior.relatedmedia/issues/25)). @ale-rt
 
 
 ## 3.7.4 (2025-04-03)

--- a/collective/behavior/relatedmedia/events.py
+++ b/collective/behavior/relatedmedia/events.py
@@ -99,10 +99,16 @@ def update_leadimage(obj, event):
     if not imgs:
         return
 
-    if not ILeadImageBehavior(obj).image:
+    lead_image_adapter = ILeadImageBehavior(obj, None)
+    if lead_image_adapter is None:
+        # The lead image adapter could not be retrieved.
+        # This usually occurs if the FTI does not list the `plone.leadimage` behavior.
+        return
+
+    if not lead_image_adapter.image:
         # set first related image as lead image (incl. caption)
-        ILeadImageBehavior(obj).image = imgs[0].image
-        ILeadImageBehavior(obj).image_caption = safe_unicode(imgs[0].Title())
+        lead_image_adapter.image = imgs[0].image
+        lead_image_adapter.image_caption = safe_unicode(imgs[0].Title())
         obj.reindexObject()
 
 


### PR DESCRIPTION
Fixes https://github.com/collective/collective.behavior.relatedmedia/issues/25